### PR TITLE
Parse holidays on config loading

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -150,8 +150,8 @@ module BusinessTime
       end
 
       def load_currency_holidays(hash, append: false)
-        hash.inject({}) do |memo, (currency, holidays)|
-          memo.merge!(currency => load_holidays(holidays, container: config[:currency_holidays][currency] ||= Container(), append: append))
+        hash.each_with_object({}) do |(currency, holidays), memo|
+          memo[currency] = load_holidays(holidays, container: config[:currency_holidays][currency] ||= Container(), append: append)
         end
       end
 

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -6,15 +6,20 @@ module BusinessTime
   # the beginning_of_workday, end_of_workday, and the list of holidays
   # manually, or with a yaml file and the load method.
   class Config
+
+    def self.Container(*args, &cb)
+      Set.new(*args, &cb)
+    end
+
     DEFAULT_CONFIG = {
-      holidays:              Set.new,
+      holidays:              Container(),
       currency_holidays:     {},
       beginning_of_workday:  '9:00 am',
       end_of_workday:        '5:00 pm',
       work_week:             %w(mon tue wed thu fri),
       work_hours:            {},
       work_hours_total:      {},
-      core_currencies:       Set.new,
+      core_currencies:       Container(),
       _weekdays:             nil
     }
 
@@ -146,7 +151,7 @@ module BusinessTime
 
       def load_currency_holidays(hash, append: false)
         hash.inject({}) do |memo, (currency, holidays)|
-          memo.merge!(currency => load_holidays(holidays, container: config[:currency_holidays][currency] ||= Set.new, append: append))
+          memo.merge!(currency => load_holidays(holidays, container: config[:currency_holidays][currency] ||= Container(), append: append))
         end
       end
 
@@ -169,7 +174,7 @@ module BusinessTime
         config_vars.each do |var|
           send("#{var}=", config[var]) if config[var] && respond_to?("#{var}=")
         end
-        load_holidays(config["holidays"] ||= Set.new, append: true)
+        load_holidays(config["holidays"] ||= Container(), append: true)
       end
 
       def with(config)

--- a/lib/business_time/currency.rb
+++ b/lib/business_time/currency.rb
@@ -1,26 +1,27 @@
 module BusinessTime
   module Currency
+
     # @return [Array] the list of currencies
     # @param [String+]
     def args(*currency)
-      return [] if currency.empty?
+      return Set.new if currency.empty?
 
       curr = if currency.length == 1 # string
-                if currency.first.length.remainder(3).zero? # 'EURUSD'
+                Set.new(if currency.first.length.remainder(3).zero? # 'EURUSD'
                   currency.first.scan /.{3}/
                 elsif currency.first.length == 7           # 'EUR|USD'
                   currency.first.split '|'
                 else
                   [''] # will raise an error below, DRY
-                end
+                end)
              else
-               currency
+               currency.to_set
              end
 
       raise ArgumentError.new("Wrong currency argument [#{currency}]") \
         unless curr.all? { |it| String === it && it.length == 3 }
 
-      curr.uniq
+      curr.merge(BusinessTime::Config.core_currencies)
     end
   end
 end

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -2,27 +2,19 @@
 module BusinessTime
   module TimeExtensions
     include BusinessTime::Currency
+
     # True if this time is on a workday (between 00:00:00 and 23:59:59), even if
     # this time falls outside of normal business hours.
     def workday?(*currency)
-      currency = args(*currency)
+      # This may BREAK currencies where weekday are not standard (IE Arabic). In that
+      # case those currencies will have 3 non work days per week
       return false unless weekday?
 
-      holidays =  if currency.empty?
-                    BusinessTime::Config.holidays
-                  else
-                    (currency + ["KX™", "LP™"]).map{|c| BusinessTime::Config.currency_holidays[c]}
-                  end              
-      holidays = holidays.flatten.map do |hd|
-                     case hd
-                     when Date then hd
-                     when DateTime then hd.to_date
-                     when String then Date.parse(hd)
-                     when ->(hd) { hd.respond_to? :to_date } then hd.to_date
-                     end
-                  end.compact
-                
-      !holidays.include?(to_date)
+      currencies = args(*currency)
+      return workday_considering_holidays?(BusinessTime::Config.holidays) if currencies.empty?
+      currencies.all? do |ccy|
+        workday_considering_holidays?(BusinessTime::Config.currency_holidays.fetch(ccy, []))
+      end
     end
 
     # True if this time falls on a weekday.
@@ -191,6 +183,10 @@ module BusinessTime
 
     def during_business_hours?(*currency)
       self.workday?(*currency) && self.to_i.between?(Time.beginning_of_workday(self).to_i, Time.end_of_workday(self).to_i)
+    end
+
+    def workday_considering_holidays?(holidays)
+      !holidays.include?(to_date)
     end
   end
 end

--- a/test/test_business_days_date_with_currencies.rb
+++ b/test/test_business_days_date_with_currencies.rb
@@ -1,16 +1,16 @@
 require File.expand_path('../helper', __FILE__)
 
 describe "business days" do
-  
+
   before do
-    BusinessTime::Config.currency_holidays = {
-      'USD' => ['2010-04-14'],
-      'GBP' => ['2010-04-15']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'USD' => [Date.civil(2010, 04, 14)],
+      'GBP' => [Date.civil(2010, 04, 15)]
+    )
   end
-  
+
   describe "with a standard Date object" do
-    
+
     it "move to day after tomorrow if we add a business day USD" do
       first = Date.parse("April 13th, 2010")
       later = [ 1.business_day('USD').after(first),
@@ -21,7 +21,7 @@ describe "business days" do
         assert_equal expected, l
       end
     end
-    
+
     it "move to April 16 when USD/GBP" do
       first = Date.parse("April 13th, 2010")
       later = [ 1.business_day('USDGBP').after(first),
@@ -33,6 +33,6 @@ describe "business days" do
         assert_equal expected, l
       end
     end
-    
+
   end
 end

--- a/test/test_business_days_utc_with_currencies.rb
+++ b/test/test_business_days_utc_with_currencies.rb
@@ -2,21 +2,21 @@ require File.expand_path('../helper', __FILE__)
 
 describe "business days" do
   describe "with a TimeWithZone object set to UTC" do
-    before { 
-      Time.zone = 'UTC' 
-      BusinessTime::Config.currency_holidays = {
-        'USD' => ['2010-04-14'],
-        'GBP' => ['2010-04-12'],
-        'EUR' => ['2010-04-15']
-      }}
-    
-    
+    before {
+      Time.zone = 'UTC'
+      BusinessTime::Config.load_currency_holidays(
+        'USD' => [Date.civil(2010, 04, 14)],
+        'GBP' => [Date.civil(2010, 04, 12)],
+        'EUR' => [Date.civil(2010, 04, 15)]
+      )
+    }
+
     it "move to day after tomorrow if we add a business day" do
       first = Time.zone.parse("April 13th, 2010, 11:00 am")
       later = [ 1.business_day('USD').after(first),
                 1.business_day('USDPLN').after(first),
                 1.business_day('USD', 'PLN').after(first) ]
-                
+
       expected = Time.zone.parse("April 15th, 2010, 11:00 am")
       later.each do |l|
         assert_equal expected, l
@@ -25,8 +25,8 @@ describe "business days" do
 
     it "move to April 9 is we subtract a business day" do
       first = Time.zone.parse("April 13th, 2010, 11:00 am")
-      before = [  1.business_day('GBP').before(first), 
-                  1.business_day('GBP', 'PLN').before(first), 
+      before = [  1.business_day('GBP').before(first),
+                  1.business_day('GBP', 'PLN').before(first),
                   1.business_day('GBPPLN').before(first) ]
       expected = Time.zone.parse("April 9th, 2010, 11:00 am")
       before.each do |b|
@@ -40,7 +40,7 @@ describe "business days" do
                 1.business_day('USDEUR').after(first),
                 1.business_day('USD', 'EUR').after(first),
                 1.business_day('USD', 'EUR', 'PLN').after(first) ]
-                
+
       expected = Time.zone.parse("April 16th, 2010, 11:00 am")
       later.each do |l|
         assert_equal expected, l

--- a/test/test_business_days_with_currencies.rb
+++ b/test/test_business_days_with_currencies.rb
@@ -2,11 +2,11 @@ require File.expand_path('../helper', __FILE__)
 
 describe "business days with currencies" do
   before do
-    BusinessTime::Config.currency_holidays = {
-      'EUR' => ['2015-01-12', '2015-05-01'],
-      'USD' => ['2015-05-04'],
-      'GBP' => ['2015-05-05']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'EUR' => [Date.civil(2015, 01, 12), Date.civil(2015, 05, 01)],
+      'USD' => [Date.civil(2015, 05, 04)],
+      'GBP' => [Date.civil(2015, 05, 05)]
+    )
   end
 
   describe "with a standard Time object" do
@@ -16,7 +16,7 @@ describe "business days with currencies" do
       expected = Time.parse("May 4th, 2015, 11:00 am")
       assert_equal expected, later
     end
-  
+
     it "should move to Tuesday as first business day after April 30 USD/EUR" do
       first = Time.parse("April 30th, 2015, 11:00 am")
       later = [ 1.business_day('EURUSD').after(first),
@@ -35,14 +35,14 @@ describe "business days with currencies" do
         assert_equal expected, l
       end
     end
-    
+
     it "moves to Wednesday from April 30 USD/EUR/GBP" do
       first = Time.parse("April 30th, 2015, 11:00 am")
       later = 1.business_day('USD', 'GBP', 'EUR').after(first)
       expected = Time.parse("May 6th, 2015, 11:00 am")
       assert_equal expected, later
     end
-    
+
     it "moves to Friday as first business day after April 30 USD" do
       first = Time.parse("April 30th, 2015, 11:00 am")
       later = 1.business_day('USD').after(first)

--- a/test/test_business_time_until_eastern.rb
+++ b/test/test_business_time_until_eastern.rb
@@ -5,10 +5,10 @@ describe "#business_time_until" do
     before do
       ENV['TZ'] = 'Pacific Time (US & Canada)'
       Time.zone = 'Eastern Time (US & Canada)'
-      BusinessTime::Config.currency_holidays = {
-        'USD' => ['2014-02-17'],
-        'GBP' => ['2010-04-15']
-      }
+      BusinessTime::Config.load_currency_holidays(
+        'USD' => [Date.civil(2014, 2, 17)],
+        'GBP' => [Date.civil(2010, 4, 15)]
+      )
     end
 
     it "should respect the time zone" do
@@ -21,7 +21,6 @@ describe "#business_time_until" do
       nine_o_clock = Time.zone.parse("2014-02-17 09:00:00")
       three_o_clock = Time.zone.parse("2014-02-17 15:00:00")
       four_o_clock = Time.zone.parse("2014-02-17 16:00:00")
-
       time = [  three_o_clock.business_time_until(four_o_clock),
                 three_o_clock.business_time_until(four_o_clock, 'GBP'),
                 three_o_clock.business_time_until(four_o_clock, 'GBPEUR'),
@@ -45,9 +44,8 @@ describe "#business_time_until" do
                 three_o_clock.business_time_until(four_o_clock, 'USDEUR'),
                 three_o_clock.business_time_until(four_o_clock, 'USD', 'EUR') ]
       time.each do |t|
-        assert_equal 0, t
+        assert_equal 0, t, t
       end
     end
-
   end
 end

--- a/test/test_calculating_business_dates_with_currencies.rb
+++ b/test/test_calculating_business_dates_with_currencies.rb
@@ -3,9 +3,9 @@ require File.expand_path('../helper', __FILE__)
 describe "calculating business dates" do
 
   before do
-    BusinessTime::Config.currency_holidays = {
-      'USD' => ['2010-12-27']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'USD' => [Date.civil(2010, 12, 27)]
+    )
   end
 
   it "properly calculate business dates over weekends plus USD Monday holiday" do

--- a/test/test_calculating_business_duration.rb
+++ b/test/test_calculating_business_duration.rb
@@ -78,7 +78,7 @@ describe "calculating business duration" do
         mon: ["08:00", "20:00"],
         tue: ["08:00", "20:00"],
     }
-    BusinessTime::Config.holidays = []
+    BusinessTime::Config.load_holidays(Set.new)
 
     created_at = Time.local(2014, 05, 12, 20, 50) #yesterday night 20:50
     published_at = Time.local(2014, 05, 13, 8, 10) #today morning 08:10

--- a/test/test_calculating_business_duration_with_currencies.rb
+++ b/test/test_calculating_business_duration_with_currencies.rb
@@ -3,9 +3,9 @@ require File.expand_path('../helper', __FILE__)
 describe "calculating business duration" do
 
   before do
-    BusinessTime::Config.currency_holidays = {
-      'USD' => ['2010-12-21', '2010-12-25', '2012-05-29']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'USD' => [Date.civil(2010, 12, 21), Date.civil(2010, 12, 25), Date.civil(2012, 05, 29)]
+    )
   end
 
   it "properly calculate business duration" do
@@ -30,17 +30,16 @@ describe "calculating business duration" do
   end
 
   it "properly calculate business time with respect to work_hours with UTC time zone" do
-    Time.zone = 'UTC'
-
-    monday = Time.parse("May 28 11:04:26 +0300 2012")
-    tuesday = Time.parse("May 29 17:56:45 +0300 2012")
-    BusinessTime::Config.work_hours = {
-        :mon => ["9:00", "18:00"],
-        :tue => ["9:00", "18:00"],
-        :wed => ["9:00", "18:00"]
-    }
-    assert_equal 32400.0, monday.business_time_until(tuesday, 'USD')
-    Time.zone = nil
+    Time.use_zone('UTC') do
+      monday = Time.zone.parse("May 28 11:04:26 +0300 2012")
+      tuesday = Time.zone.parse("May 29 17:56:45 +0300 2012")
+      BusinessTime::Config.work_hours = {
+          :mon => ["9:00", "18:00"],
+          :tue => ["9:00", "18:00"],
+          :wed => ["9:00", "18:00"]
+      }
+      assert_equal 32400.0, monday.business_time_until(tuesday, 'USD')
+    end
   end
-
 end
+

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -171,7 +171,7 @@ describe "config" do
   end
 
   it "supports old string format" do
-    BusinessTime::Config.load_currency_holidays({'USD' => ['2010-04-9']}, accept_parsing: true)
+    BusinessTime::Config.load_currency_holidays({'USD' => ['2010-04-9']})
     assert_equal Set.new([Date.civil(2010, 4, 9)]), BusinessTime::Config.currency_holidays['USD']
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -77,7 +77,7 @@ describe "config" do
     assert_equal "11:00 am", BusinessTime::Config.beginning_of_workday
     assert_equal "2:00 pm", BusinessTime::Config.end_of_workday
     assert_equal ['mon'], BusinessTime::Config.work_week
-    assert_equal [Date.parse('2012-12-25')], BusinessTime::Config.holidays
+    assert_equal Set.new([Date.parse('2012-12-25')]), BusinessTime::Config.holidays
   end
 
   it "include holidays read from YAML config files" do
@@ -102,7 +102,7 @@ describe "config" do
     assert_equal "9:00 am", BusinessTime::Config.beginning_of_workday
     assert_equal "5:00 pm", BusinessTime::Config.end_of_workday
     assert_equal %w[mon tue wed thu fri], BusinessTime::Config.work_week
-    assert_equal [], BusinessTime::Config.holidays
+    assert_empty BusinessTime::Config.holidays
   end
 
   it "is threadsafe" do
@@ -168,5 +168,10 @@ describe "config" do
         end
       end.join
     end
+  end
+
+  it "supports old string format" do
+    BusinessTime::Config.load_currency_holidays({'USD' => ['2010-04-9']}, accept_parsing: true)
+    assert_equal Set.new([Date.civil(2010, 4, 9)]), BusinessTime::Config.currency_holidays['USD']
   end
 end

--- a/test/test_currency.rb
+++ b/test/test_currency.rb
@@ -2,7 +2,7 @@ require File.expand_path('../helper', __FILE__)
 
 describe "currency" do
   include BusinessTime::Currency
-  
+
   let(:valid) {
     {
       'EUR' => ['EUR'],
@@ -10,7 +10,7 @@ describe "currency" do
       'USDEUR' => ['EUR', 'USD'],
       'EUR|USD' => ['EUR', 'USD'],
       'USD|EUR' => ['EUR', 'USD'],
-      
+
       ['EUR'] => ['EUR'],
       ['EURUSD'] => ['EUR', 'USD'],
       ['USDEUR'] => ['EUR', 'USD'],
@@ -22,7 +22,7 @@ describe "currency" do
       ['PLN', 'EUR', 'USD'] => ['EUR', 'USD', 'PLN'],
     }
   }
-  
+
   let(:invalid) {
     [
       'EU', 'EURUS', ['US'],
@@ -32,15 +32,15 @@ describe "currency" do
       [nil, 'EUR'],
     ]
   }
-  
+
   describe 'args' do
     it "correctly processes arguments" do
       valid.each do |k,v|
         assert_equal args(*k).sort, v.sort
       end
-      assert_equal args(), []
+      assert_empty args()
     end
-    
+
     it "Raises argument error" do
       invalid.each do |i|
         assert_raises ArgumentError do
@@ -48,6 +48,6 @@ describe "currency" do
         end
       end
     end
-    
+
   end
 end

--- a/test/test_date_extensions.rb
+++ b/test/test_date_extensions.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../helper', __FILE__)
 
 describe "date extensions" do
-  
+
   before do
-    BusinessTime::Config.currency_holidays = {
-      'USD' => ['2010-04-14'],
-      'GBP' => ['2010-04-15']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'USD' => [Date.civil(2010, 04, 14)],
+      'GBP' => [Date.civil(2010, 04, 15)]
+    )
   end
-  
+
   it "know a weekend day is not a workday"  do
     assert(Date.parse("April 9, 2010").workday?)
     assert(!Date.parse("April 10, 2010").workday?)
@@ -37,17 +37,17 @@ describe "date extensions" do
     assert(!july_4.workday?)
     assert(!july_5.workday?)
   end
-  
+
   it "currency holidays" do
     july_5 = Date.parse("July 5, 2010")
 
     assert(july_5.workday?('USD'))
-    
-    BusinessTime::Config.currency_holidays = {'USD' => ['2010-07-05']}
+
+    BusinessTime::Config.load_currency_holidays('USD' => [Date.civil(2010, 07, 05)])
     assert(!july_5.workday?('USD'))
     assert(july_5.workday?('EUR'))
   end
-  
+
   it "currency workdays" do
     assert(Date.parse("April 9, 2010").workday?('USD'))
     assert(Date.parse("April 9, 2010").workday?('USDEUR'))
@@ -56,5 +56,5 @@ describe "date extensions" do
     assert(!Date.parse("April 14, 2010").workday?('USDEUR'))
     assert(!Date.parse("April 14, 2010").workday?('USD', 'EUR'))
   end
-  
+
 end

--- a/test/test_fixnum_extensions.rb
+++ b/test/test_fixnum_extensions.rb
@@ -2,13 +2,13 @@ require File.expand_path('../helper', __FILE__)
 
 describe "fixnum extensions" do
   before do
-    BusinessTime::Config.currency_holidays = {
-      'EUR' => ['2015-01-12', '2015-05-01'],
-      'USD' => ['2015-05-04'],
-      'GBP' => ['2015-05-05']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'EUR' => [Date.civil(2015, 01, 12), Date.civil(2015, 05, 01)],
+      'USD' => [Date.civil(2015, 05, 04)],
+      'GBP' => [Date.civil(2015, 05, 05)]
+    )
   end
-  
+
   it "respond to business_hours by returning an instance of BusinessHours" do
     assert(1.respond_to?(:business_hour))
     assert(1.respond_to?(:business_hours))

--- a/test/test_time_extensions.rb
+++ b/test/test_time_extensions.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../helper', __FILE__)
 
 describe "time extensions" do
-  
+
   before do
-    BusinessTime::Config.currency_holidays = {
-      'USD' => ['2010-04-9'],
-      'GBP' => ['2010-04-12']
-    }
+    BusinessTime::Config.load_currency_holidays(
+      'USD' => [Date.civil(2010, 4, 9)],
+      'GBP' => [Date.civil(2010, 4, 12)]
+    )
   end
-  
+
   it "currency workday" do
     assert( Time.parse("April 9, 2010 10:45 am").workday?('GBP'))
     assert(!Time.parse("April 9, 2010 10:45 am").workday?('USD'))
@@ -17,13 +17,13 @@ describe "time extensions" do
     assert( Time.parse("April 12, 2010 10:45 am").workday?('USD'))
     assert(!Time.parse("April 12, 2010 10:45 am").workday?('GBP'))
   end
-  
+
   it "know a weekend day is not a workday" do
     assert( Time.parse("April 9, 2010 10:45 am").workday?)
     assert(!Time.parse("April 10, 2010 10:45 am").workday?)
     assert(!Time.parse("April 11, 2010 10:45 am").workday?)
     assert( Time.parse("April 12, 2010 10:45 am").workday?)
-    
+
     assert( Time.parse("April 12, 2010 10:45 am").workday?('USD'))
     assert(!Time.parse("April 10, 2010 10:45 am").workday?('GBPUSD'))
     assert(!Time.parse("April 11, 2010 10:45 am").workday?('USD', 'EUR'))
@@ -109,7 +109,7 @@ describe "time extensions" do
     ticket_resolved = Time.parse("February 4, 2012, 10:40 am") #will roll over to Monday morning, 9:00am
     assert_equal ticket_reported.business_time_until(ticket_resolved), 6.hours + 20.minutes
   end
-  
+
   it "knows if within business hours" do
     assert(Time.parse("2013-02-01 10:00").during_business_hours?)
     assert(!Time.parse("2013-02-01 5:00").during_business_hours?)
@@ -152,4 +152,6 @@ describe "time extensions" do
     }
     assert_equal wednesday, Time.roll_backward(saturday)
   end
+
+
 end

--- a/test/test_time_extensions_holidays.rb
+++ b/test/test_time_extensions_holidays.rb
@@ -2,51 +2,56 @@ require File.expand_path('../helper', __FILE__)
 
 describe "holidays" do
   before do
-    BusinessTime::Config.currency_holidays = {
-      "KX™" => ['2015-01-07'],
-      "LP™" => ['2015-01-08']
-    }
-    BusinessTime::Config.holidays = ['2015-01-05']
+    BusinessTime::Config.load_currency_holidays(
+      "KX™" => [Date.civil(2015, 1, 7)],
+      "LP™" => [Date.civil(2015, 1, 8)]
+    )
+    BusinessTime::Config.load_holidays([Date.strptime('2015-01-05', "%F")])
+    BusinessTime::Config.core_currencies = ["KX™", "LP™"]
   end
-  
+
+  after do |example|
+    BusinessTime::Config.default_config
+  end
+
   let(:params) {
     [['USD'], ['USD|EUR'], ['USDEUR'], ['USD', 'EUR'], ['USD', 'GBP', 'EUR']]
   }
-  
+
   it "takes into account default holidays when no currency specified" do
     assert(!Time.parse("2015-01-05").workday?)
     assert( Time.parse("2015-01-06").workday?)
   end
-  
+
   it "takes into account kantox holidays with any currency" do
     day = Time.parse("2015-01-07")
     params.each do |p|
       assert(!day.workday?(*p))
     end
-    
+
     BusinessTime::Config.currency_holidays["KX™"] = []
     params.each do |p|
       assert( day.workday?(*p))
     end
   end
-  
+
   it "takes into account lp holidays with any currency" do
     day = Time.parse("2015-01-08")
     params.each do |p|
       assert(!day.workday?(*p))
     end
-    
+
     BusinessTime::Config.currency_holidays["LP™"] = []
     params.each do |p|
       assert( day.workday?(*p))
     end
   end
-  
+
   it "works" do
     day = Time.parse("2015-01-09")
     params.each do |p|
       assert( day.workday?(*p))
     end
   end
-  
+
 end

--- a/test/test_time_extensions_holidays.rb
+++ b/test/test_time_extensions_holidays.rb
@@ -10,10 +10,6 @@ describe "holidays" do
     BusinessTime::Config.core_currencies = ["KX™", "LP™"]
   end
 
-  after do |example|
-    BusinessTime::Config.default_config
-  end
-
   let(:params) {
     [['USD'], ['USD|EUR'], ['USDEUR'], ['USD', 'EUR'], ['USD', 'GBP', 'EUR']]
   }

--- a/test/test_time_with_zone_extensions.rb
+++ b/test/test_time_with_zone_extensions.rb
@@ -4,12 +4,12 @@ describe "TimeWithZone extensions" do
   describe "With Eastern Standard Time" do
     before do
       Time.zone = 'Eastern Time (US & Canada)'
-      BusinessTime::Config.currency_holidays = {
-        'USD' => ['2010-04-9'],
-        'GBP' => ['2010-04-12']
-      }
+      BusinessTime::Config.load_currency_holidays(
+        'USD' => [Date.civil(2010, 04, 9)],
+        'GBP' => [Date.civil(2010, 04, 12)]
+      )
     end
-    
+
     it "currency workday" do
       assert( Time.parse("April 9, 2010 10:45 am").workday?('GBP'))
       assert(!Time.parse("April 9, 2010 10:45 am").workday?('USD'))
@@ -18,13 +18,13 @@ describe "TimeWithZone extensions" do
       assert( Time.parse("April 12, 2010 10:45 am").workday?('USD'))
       assert(!Time.parse("April 12, 2010 10:45 am").workday?('GBP'))
     end
-    
+
     it "know a weekend day is not a workday" do
       assert( Time.parse("April 9, 2010 10:45 am").workday?)
       assert(!Time.parse("April 10, 2010 10:45 am").workday?)
       assert(!Time.parse("April 11, 2010 10:45 am").workday?)
       assert( Time.parse("April 12, 2010 10:45 am").workday?)
-      
+
       assert( Time.parse("April 12, 2010 10:45 am").workday?('USD'))
       assert(!Time.parse("April 10, 2010 10:45 am").workday?('GBPUSD'))
       assert(!Time.parse("April 11, 2010 10:45 am").workday?('USD', 'EUR'))


### PR DESCRIPTION
Proposal to normalize dates in BusinessTime::Config (`holidays` and `currency_holidays`), for now on will always be Date objects to speedup runtime checks.

The API changed and forces to use `BusinessTime::Config.load_holidays` and `BusinessTime::Config.load_currency_holidays` instead of the module accessor. I added a deprecation warning when this new methods are fed with non Date objects (String, Time, etc.)
